### PR TITLE
Fixed images being sideways issue as well as thumbnails being to big

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .venv/
 
 __pycache__/
+
+index.html

--- a/generate_thumbnails.py
+++ b/generate_thumbnails.py
@@ -36,6 +36,7 @@ def parse_args():
     parser.add_argument(
         "--thumb-size", 
         default=THUMB_SIZE, 
+        type=int,
         nargs=2, 
         metavar=("WIDTH", "HEIGHT"), 
         help="Size in pixels of the generated thumbnails. Default is specified in config.py."

--- a/generate_thumbnails.py
+++ b/generate_thumbnails.py
@@ -4,7 +4,7 @@
 # third party
 import os
 import argparse
-from PIL import Image
+from PIL import Image, ImageOps
 
 # mine
 from config import *
@@ -12,6 +12,7 @@ from directory_scanner import *
 
 def generate_thumbnail(image_path, thumb_size, thumb_name):
     image = Image.open(image_path)
+    image = ImageOps.exif_transpose(image)
     image.thumbnail(thumb_size)
     image.save(thumb_name)
 


### PR DESCRIPTION
Pretty simple fix, simply changed thumbnail generation to include exif data of the original picture, thus using the orientation exif flag. To fix the thumbnail size issue I simply just ran the script with a smaller thumbnail size argument.